### PR TITLE
feat(tool): add ms logging module

### DIFF
--- a/src/log/logging.ts
+++ b/src/log/logging.ts
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import * as util from 'util';
+import { Disposable, LogOutputChannel } from 'vscode';
+
+type Arguments = unknown[];
+class OutputChannelLogger {
+    constructor(private readonly channel: LogOutputChannel) {}
+
+    public traceLog(...data: Arguments): void {
+        this.channel.appendLine(util.format(...data));
+    }
+
+    public traceError(...data: Arguments): void {
+        this.channel.error(util.format(...data));
+    }
+
+    public traceWarn(...data: Arguments): void {
+        this.channel.warn(util.format(...data));
+    }
+
+    public traceInfo(...data: Arguments): void {
+        this.channel.info(util.format(...data));
+    }
+
+    public traceVerbose(...data: Arguments): void {
+        this.channel.debug(util.format(...data));
+    }
+}
+
+let channel: OutputChannelLogger | undefined;
+export function registerLogger(logChannel: LogOutputChannel): Disposable {
+    channel = new OutputChannelLogger(logChannel);
+    return {
+        dispose: () => {
+            channel = undefined;
+        },
+    };
+}
+
+export function traceLog(...args: Arguments): void {
+    channel?.traceLog(...args);
+}
+
+export function traceError(...args: Arguments): void {
+    channel?.traceError(...args);
+}
+
+export function traceWarn(...args: Arguments): void {
+    channel?.traceWarn(...args);
+}
+
+export function traceInfo(...args: Arguments): void {
+    channel?.traceInfo(...args);
+}
+
+export function traceVerbose(...args: Arguments): void {
+    channel?.traceVerbose(...args);
+}


### PR DESCRIPTION
This pull request introduces a new logging utility for the project. The key changes include the addition of a new class, `OutputChannelLogger`, and several functions to facilitate logging at various levels.

### Logging Utility Additions:

* [`src/log/logging.ts`](diffhunk://#diff-ecf2d884ca0fbfeae57b25ba3bc880754581a7e49338f8c2cc25e38796b5aabbR1-R60): Added a new class `OutputChannelLogger` to handle logging with methods for different log levels (`traceLog`, `traceError`, `traceWarn`, `traceInfo`, `traceVerbose`).
* [`src/log/logging.ts`](diffhunk://#diff-ecf2d884ca0fbfeae57b25ba3bc880754581a7e49338f8c2cc25e38796b5aabbR1-R60): Added functions `traceLog`, `traceError`, `traceWarn`, `traceInfo`, and `traceVerbose` to provide a simplified interface for logging.
* [`src/log/logging.ts`](diffhunk://#diff-ecf2d884ca0fbfeae57b25ba3bc880754581a7e49338f8c2cc25e38796b5aabbR1-R60): Added a `registerLogger` function to initialize the logger with a `LogOutputChannel` and provide a disposable to clean up the logger.