### PR TITLE
feat(api): add pypi data types & post processor

### DIFF
--- a/src/api/pypi-index-server.ts
+++ b/src/api/pypi-index-server.ts
@@ -1,0 +1,35 @@
+import axios from 'axios';
+import { PyPiPackageMetadatas } from './pypiMetadatas';
+const NodeCache = require('node-cache');
+
+const cache = new NodeCache({ stdTTL: 60 * 10 });
+
+export const versions = (name: string, indexServerURL: string = 'https://pypi.org/pypi') => {
+    // clean dirty names
+    name = name.replace(/"/g, '');
+
+    return new Promise<PyPiPackageMetadatas>(async function (resolve, reject) {
+        const cached = cache.get(name) as PyPiPackageMetadatas | undefined;
+        if (cached) {
+            resolve(cached);
+            return;
+        }
+        try {
+            const response = await axios.get(`${indexServerURL}/${name}/json`);
+            // reject on bad status
+            if (response.status < 200 || response.status >= 300) {
+                return reject(new Error('statusCode=' + response.status));
+            }
+            // process response data
+            try {
+                const package_metadatas: PyPiPackageMetadatas = response.data;
+                cache.set(name, package_metadatas);
+                resolve(package_metadatas);
+            } catch (e) {
+                reject(e);
+            }
+        } catch (error) {
+            reject(error);
+        }
+    });
+};

--- a/src/api/pypiMetadatas.ts
+++ b/src/api/pypiMetadatas.ts
@@ -1,0 +1,5 @@
+export type PyPiPackageMetadatas = {
+    name: string,
+    versions: Array<string>,
+    classifiers: Array<string>
+}


### PR DESCRIPTION
This pull request introduces a new feature to fetch and cache metadata for PyPi packages. The most important changes include adding a new function to fetch package metadata, implementing caching to improve performance, and defining a type for the metadata.

New feature implementation:

* [`src/api/pypi-index-server.ts`](diffhunk://#diff-f891b97b7a779f62b35316a4f9f408aa4d398f4d2c54a618d342954e7a6dc5c9R1-R35): Added a new function `versions` that fetches metadata for a given PyPi package, processes the response, and caches the results using `node-cache` for improved performance.

Type definitions:

* [`src/api/pypiMetadatas.ts`](diffhunk://#diff-d7aa40898ddd39c8fff5781950802e36004aa27b82bd013e6d3520b39c945a36R1-R5): Defined a new type `PyPiPackageMetadatas` to structure the metadata fetched from the PyPi index server.