### PR TITLE
feat(api): add pypi index fetcher

### DIFF
--- a/src/api/sparse-index-server.ts
+++ b/src/api/sparse-index-server.ts
@@ -1,0 +1,61 @@
+import axios from 'axios';
+// Use require for NodeCache to avoid TypeScript errors
+const NodeCache = require('node-cache');
+
+export const pypiIndexServerURL = "https://pypi.org/pypi";
+const cache = new NodeCache({ stdTTL: 60 * 10 });
+
+export const versions = (name: string, indexServerURL: string = pypiIndexServerURL) => {
+    // clean dirty names
+    name = name.replace(/"/g, "");
+
+    return new Promise<any>(async function (resolve, reject) {
+        const cached = cache.get(name) as any;
+        if (cached) {
+            resolve(cached);
+            return;
+        }
+
+        try {
+            const response = await axios.get(`${indexServerURL}/${name}/json`);
+            if (response.status < 200 || response.status >= 300) {
+                return reject(new Error('statusCode=' + response.status));
+            }
+
+            const packageMetadatas = {
+                name: name,
+                versions: Object.keys(response.data.releases),
+                features: response.data.info.classifiers
+            };
+
+            cache.set(name, packageMetadatas);
+            resolve(packageMetadatas);
+        } catch (e) {
+            reject(e);
+        }
+    });
+};
+
+// Check if `pypi` is reachable
+export async function isPypiReachable(indexServerURL: string = pypiIndexServerURL): Promise<boolean> {
+    return new Promise<boolean>(async function (resolve, reject) {
+        const cached = cache.get(indexServerURL) as boolean | undefined;
+        if (cached) {
+            resolve(cached);
+            return;
+        }
+
+        try {
+            const response = await axios.get(`${indexServerURL}`);
+            if (response.status >= 200 && response.status < 300) {
+                cache.set(indexServerURL, true);
+                resolve(true);
+            } else {
+                cache.set(indexServerURL, false);
+                resolve(false);
+            }
+        } catch (e) {
+            reject(e);
+        }
+    });
+}


### PR DESCRIPTION
This pull request introduces a new file, `src/api/sparse-index-server.ts`, which adds functionality for interacting with the PyPI index server. The main changes include adding caching for package metadata and checking the reachability of the PyPI server.

Key changes:

* Added dependency on `axios` for making HTTP requests and `NodeCache` for caching responses.
* Implemented the `versions` function to retrieve and cache package metadata from the PyPI index server.
* Added the `isPypiReachable` function to check and cache the reachability of the PyPI index server.