### PR TITLE
feat(const): add common used constants

### DIFF
--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import * as path from 'path';
+
+const folderName = path.basename(__dirname);
+export const EXTENSION_ROOT_DIR =
+    folderName === 'common' ? path.dirname(path.dirname(__dirname)) : path.dirname(__dirname);
+export const BUNDLED_PYTHON_SCRIPTS_DIR = path.join(EXTENSION_ROOT_DIR, 'bundled');
+export const SERVER_SCRIPT_PATH = path.join(BUNDLED_PYTHON_SCRIPTS_DIR, 'tool', `lsp_server.py`);
+export const DEBUG_SERVER_SCRIPT_PATH = path.join(BUNDLED_PYTHON_SCRIPTS_DIR, 'tool', `_debug_server.py`);


### PR DESCRIPTION
This pull request introduces a new set of constants to the `src/core/constants.ts` file for managing paths related to the extension's root directory and bundled Python scripts.

Path management constants:

* Added `EXTENSION_ROOT_DIR` constant to determine the root directory of the extension based on the folder structure.
* Added `BUNDLED_PYTHON_SCRIPTS_DIR` constant to specify the directory where bundled Python scripts are located.
* Added `SERVER_SCRIPT_PATH` constant to define the path to the `lsp_server.py` script.
* Added `DEBUG_SERVER_SCRIPT_PATH` constant to define the path to the `_debug_server.py` script.