### PR TITLE
feat(pkg): add 'dependencies' package and its interface

### DIFF
--- a/src/core/Dependency.ts
+++ b/src/core/Dependency.ts
@@ -1,0 +1,14 @@
+import { CompletionList } from "vscode";
+import Package from "./Package";
+
+/**
+ * Dependency is a data structure to define parsed package index, versions and error
+ */
+export default interface Dependency {
+    package: Package;
+    versions?: Array<string>;
+    error?: string;
+
+    versionCompletionItems?: CompletionList;
+    featureCompletionItems?: Map<string, CompletionList>;
+}

--- a/src/core/Package.ts
+++ b/src/core/Package.ts
@@ -1,0 +1,16 @@
+export default class Package {
+    key: string = "";
+    values: Array<any> = [];
+    value: string | undefined = "";
+    start: number = -1;
+    end: number = -1;
+    constructor(pkg?: Package) {
+        if (pkg) {
+            this.key = pkg.key;
+            this.values = pkg.values;
+            this.value = pkg.value;
+            this.start = pkg.start;
+            this.end = pkg.end;
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces new data structures to handle package dependencies and their associated metadata. The most important changes include the addition of a `Dependency` interface and a `Package` class.

New data structures:

* [`src/core/Dependency.ts`](diffhunk://#diff-784e0effa7d8ad85c86c4531c8e88b2267541bc492ee9f4bd573371ec80a2278R1-R14): Added a `Dependency` interface to define parsed package index, versions, errors, and completion items.
* [`src/core/Package.ts`](diffhunk://#diff-20e56cbbbaf79be6ae3a43fee03705ae44a9cdfca1d5c45fc9783c2474cb8013R1-R16): Added a `Package` class to represent package metadata, including key, values, value, start, and end properties, along with a constructor for initialization.