### PR TITLE
feat(core): implement vscode server

### DIFF
--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -1,0 +1,126 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import * as fsapi from 'fs-extra';
+import { Disposable, env, LogOutputChannel } from 'vscode';
+import { State } from 'vscode-languageclient';
+import {
+    LanguageClient,
+    LanguageClientOptions,
+    RevealOutputChannelOn,
+    ServerOptions,
+} from 'vscode-languageclient/node';
+import { DEBUG_SERVER_SCRIPT_PATH, SERVER_SCRIPT_PATH } from './constants';
+import { traceError, traceInfo, traceVerbose } from '../log/logging';
+import { getDebuggerPath } from './python';
+import { getExtensionSettings, getGlobalSettings, getWorkspaceSettings, ISettings } from './settings';
+import { getLSClientTraceLevel, getProjectRoot } from './utilities';
+import { isVirtualWorkspace } from './vscodeapi';
+
+export type IInitOptions = { settings: ISettings[]; globalSettings: ISettings };
+
+async function createServer(
+    settings: ISettings,
+    serverId: string,
+    serverName: string,
+    outputChannel: LogOutputChannel,
+    initializationOptions: IInitOptions,
+): Promise<LanguageClient> {
+    const command = settings.interpreter[0];
+    const cwd = settings.cwd;
+
+    // Set debugger path needed for debugging python code.
+    const newEnv = { ...process.env };
+    const debuggerPath = await getDebuggerPath();
+    const isDebugScript = await fsapi.pathExists(DEBUG_SERVER_SCRIPT_PATH);
+    if (newEnv.USE_DEBUGPY && debuggerPath) {
+        newEnv.DEBUGPY_PATH = debuggerPath;
+    } else {
+        newEnv.USE_DEBUGPY = 'False';
+    }
+
+    // Set import strategy
+    newEnv.LS_IMPORT_STRATEGY = settings.importStrategy;
+
+    // Set notification type
+    newEnv.LS_SHOW_NOTIFICATION = settings.showNotifications;
+
+    const args =
+        newEnv.USE_DEBUGPY === 'False' || !isDebugScript
+            ? settings.interpreter.slice(1).concat([SERVER_SCRIPT_PATH])
+            : settings.interpreter.slice(1).concat([DEBUG_SERVER_SCRIPT_PATH]);
+    traceInfo(`Server run command: ${[command, ...args].join(' ')}`);
+
+    const serverOptions: ServerOptions = {
+        command,
+        args,
+        options: { cwd, env: newEnv },
+    };
+
+    // Options to control the language client
+    const clientOptions: LanguageClientOptions = {
+        // Register the server for python documents
+        documentSelector: isVirtualWorkspace()
+            ? [{ language: 'python' }]
+            : [
+                { scheme: 'file', language: 'python' },
+                { scheme: 'untitled', language: 'python' },
+                { scheme: 'vscode-notebook', language: 'python' },
+                { scheme: 'vscode-notebook-cell', language: 'python' },
+            ],
+        outputChannel: outputChannel,
+        traceOutputChannel: outputChannel,
+        revealOutputChannelOn: RevealOutputChannelOn.Never,
+        initializationOptions,
+    };
+
+    return new LanguageClient(serverId, serverName, serverOptions, clientOptions);
+}
+
+let _disposables: Disposable[] = [];
+export async function restartServer(
+    serverId: string,
+    serverName: string,
+    outputChannel: LogOutputChannel,
+    lsClient?: LanguageClient,
+): Promise<LanguageClient | undefined> {
+    if (lsClient) {
+        traceInfo(`Server: Stop requested`);
+        await lsClient.stop();
+        _disposables.forEach((d) => d.dispose());
+        _disposables = [];
+    }
+    const projectRoot = await getProjectRoot();
+    const workspaceSetting = await getWorkspaceSettings(serverId, projectRoot, true);
+
+    const newLSClient = await createServer(workspaceSetting, serverId, serverName, outputChannel, {
+        settings: await getExtensionSettings(serverId, true),
+        globalSettings: await getGlobalSettings(serverId, false),
+    });
+    traceInfo(`Server: Start requested.`);
+    _disposables.push(
+        newLSClient.onDidChangeState((e) => {
+            switch (e.newState) {
+                case State.Stopped:
+                    traceVerbose(`Server State: Stopped`);
+                    break;
+                case State.Starting:
+                    traceVerbose(`Server State: Starting`);
+                    break;
+                case State.Running:
+                    traceVerbose(`Server State: Running`);
+                    break;
+            }
+        }),
+    );
+    try {
+        await newLSClient.start();
+    } catch (ex) {
+        traceError(`Server: Start failed: ${ex}`);
+        return undefined;
+    }
+
+    const level = getLSClientTraceLevel(outputChannel.logLevel, env.logLevel);
+    await newLSClient.setTrace(level);
+    return newLSClient;
+}


### PR DESCRIPTION
This pull request introduces significant changes to the `src/core/server.ts` file, focusing on creating and managing a language server for Python. The most important changes include the implementation of the `createServer` and `restartServer` functions, which handle the initialization and restarting of the language server with appropriate settings and environment configurations.

Key changes:

* **Server Initialization:**
  * Implemented the `createServer` function to initialize a `LanguageClient` with the necessary server and client options, including environment variables for debugging and import strategies.

* **Server Restart:**
  * Added the `restartServer` function to handle stopping an existing language server, disposing of resources, and starting a new server instance with updated settings.

* **Environment Configuration:**
  * Configured environment variables such as `USE_DEBUGPY`, `DEBUGPY_PATH`, `LS_IMPORT_STRATEGY`, and `LS_SHOW_NOTIFICATION` within the `createServer` function to control the server's behavior.

* **Client Options:**
  * Set up `LanguageClientOptions` to register the server for Python documents, manage output channels, and handle initialization options.

* **Logging and Tracing:**
  * Integrated logging and tracing mechanisms to monitor server state changes and log relevant information for debugging purposes. (F1cfc