### PR TITLE
feat(core): implement extension checking

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,0 +1,103 @@
+'use strict';
+/**
+ * This extension helps to manage Python package dependency versions.
+ * It supports both pyproject.toml and requirements.txt files.
+ */
+import {
+    window,
+    workspace,
+    ExtensionContext,
+    TextDocumentChangeEvent,
+    languages,
+    DocumentSelector,
+    CodeActionKind,
+} from 'vscode';
+import pyListener from './core/listener';
+import PyCommands from './toml/commands';
+import { VersionCompletions, FeaturesCompletions } from './providers/autoCompletion';
+import { QuickActions } from './providers/quickAction';
+import { quickFillListener } from './providers/quickFill';
+import { CursorTracker } from './providers/cursorTracker';
+
+export function activate(context: ExtensionContext) {
+    // Support both pyproject.toml and requirements.txt files
+    const tomlSelector: DocumentSelector = { language: 'toml', pattern: '**/pyproject.toml' };
+    const requirementsSelector: DocumentSelector = { pattern: '**/requirements*.txt' };
+
+    context.subscriptions.push(
+        // Add active text editor listener and run once on start.
+        window.onDidChangeActiveTextEditor(pyListener),
+
+        // When the text document is changed, fetch + check dependencies
+        workspace.onDidChangeTextDocument((e: TextDocumentChangeEvent) => {
+            const { fileName } = e.document;
+            if (
+                fileName.toLocaleLowerCase().endsWith('pyproject.toml') ||
+                (fileName.toLocaleLowerCase().includes('requirements') && fileName.toLocaleLowerCase().endsWith('.txt'))
+            ) {
+                if (!e.document.isDirty) {
+                    pyListener(window.activeTextEditor);
+                }
+
+                // Handle quick fill functionality (typing "?" to auto-fill latest version)
+                quickFillListener(e);
+            }
+        }),
+
+        // Register the versions completions provider for both file types
+        languages.registerCompletionItemProvider(
+            tomlSelector,
+            new VersionCompletions(),
+            "'",
+            '"',
+            '.',
+            '+',
+            '-',
+            '=',
+            '0',
+            '1',
+            '2',
+            '3',
+            '4',
+            '5',
+            '6',
+            '7',
+            '8',
+            '9',
+        ),
+
+        languages.registerCompletionItemProvider(
+            requirementsSelector,
+            new VersionCompletions(),
+            '=',
+            '~',
+            '>',
+            '<',
+            '^',
+            '!',
+            ' ',
+        ),
+
+        // Register the Quick Actions provider
+        languages.registerCodeActionsProvider([tomlSelector, requirementsSelector], new QuickActions(), {
+            providedCodeActionKinds: [CodeActionKind.QuickFix],
+        }),
+
+        // Register the features auto completions provider
+        languages.registerCompletionItemProvider(tomlSelector, new FeaturesCompletions(), "'", '"'),
+    );
+
+    pyListener(window.activeTextEditor);
+
+    // Add commands
+    context.subscriptions.push(PyCommands.replaceVersion);
+
+    // Start the cursor tracker for idle detection
+    const cursorTracker = new CursorTracker();
+    cursorTracker.start();
+    context.subscriptions.push({
+        dispose: () => cursorTracker.dispose(),
+    });
+}
+
+export function deactivate() {}


### PR DESCRIPTION
This pull request introduces a new extension to manage Python package dependency versions by supporting both `pyproject.toml` and `requirements.txt` files. The changes include adding listeners, completion providers, and quick actions to enhance the functionality of the extension.

Key changes:

* **Extension Initialization**:
  * Added the `activate` function to initialize the extension, set up listeners, and register providers for `pyproject.toml` and `requirements.txt` files.
  * Added the `deactivate` function as a placeholder for clean-up logic.

* **Listeners and Providers**:
  * Added a listener for active text editor changes and text document changes to manage dependency checks and auto-fill functionality.
  * Registered completion item providers for version completions and features completions for supported file types.
  * Registered a code actions provider for quick fixes in both `pyproject.toml` and `requirements.txt` files.

* **Commands and Cursor Tracking**:
  * Added a command for replacing version numbers and started a cursor tracker for idle detection.

These changes collectively enhance the user experience by providing automated dependency management and quick actions for Python projects.