### PR TITLE
ci(hooks): update linting tools

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,10 @@
 repos:
+  - repo: https://github.com/pre-commit/mirrors-eslint
+    rev: v9.34.0
+    hooks:
+      - id: eslint
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-yaml
         args:
@@ -11,12 +15,15 @@ repos:
       - id: check-added-large-files
         args:
           - --maxkb=1024
+        stages:
+          - pre-commit
+      - id: requirements-txt-fixer
       - id: check-merge-conflict
+      - id: debug-statements
       - id: pretty-format-json
         args:
           - --autofix
           - --indent=2
-      - id: debug-statements
   - repo: local
     hooks:
       - id: validate-commit-msg
@@ -27,3 +34,8 @@ repos:
         language: pygrep
         stages:
           - commit-msg
+      - id: tsc-check
+        name: TypeScript type check
+        entry: npx tsc --noEmit
+        language: system
+        files: \.(ts|tsx)$


### PR DESCRIPTION
This pull request updates the `.pre-commit-config.yaml` to enhance code quality checks and developer workflow. The most important changes include adding new hooks for JavaScript/TypeScript linting and type checking, updating existing hooks to newer versions, and improving configuration for handling large files.

**Pre-commit hook additions and updates:**

* Added `eslint` hook for JavaScript/TypeScript linting using the `pre-commit/mirrors-eslint` repository.
* Updated `pre-commit-hooks` repository from version `v5.0.0` to `v6.0.0`, which includes improvements and new hooks.

**New quality and safety checks:**

* Added `requirements-txt-fixer` and `debug-statements` hooks for Python code quality, and improved the configuration of the `check-added-large-files` hook to specify the `pre-commit` stage.
* Added a new `tsc-check` hook for TypeScript type checking, which runs `npx tsc --noEmit` on `.ts` and `.tsx` files to catch type errors before commits.