### PR TITLE
ci(ignore): update ignore files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@ wheels/
 .installed.cfg
 *.egg
 MANIFEST
+tmp
+local
 
 # PyInstaller
 #  Usually these files are written by a python script from a template
@@ -139,12 +141,14 @@ pyrightconfig.json
 # Go Project
 vendor
 _vendor*
-.hc.yaml
+.pcg.yaml
+mise.toml
 
 # Project Level 👇
 # Remove the existed one or use anti pattern ! to allow some patterns if needed
 ut
 dist
+out
 node_modules
 .vscode-test/
 *.vsix

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -12,7 +12,13 @@ vsc-extension-quickstart.md
 **/*.ts
 .venv/**
 .nox/**
-.github/
+# Exclude most .github files but keep LICENSE
+.github/development.md
+.github/CONTRIBUTING.md
+.github/INSTALL.md
+.github/CODE_OF_CONDUCT.md
+.github/SECURITY.md
+.github/SUPPORT.md
 **/__pycache__/**
 **/.pyc
 bundled/libs/bin/**


### PR DESCRIPTION
This pull request updates the `.vscodeignore` file to refine which `.github` files are excluded from the VS Code extension package. Instead of excluding the entire `.github` directory, it now specifically excludes individual documentation and support files.

Documentation and support file exclusion:

* [`.vscodeignore`](diffhunk://#diff-0a721cd4753ff50bbbe1237397c3c7692080254fa766268fcc8b05ef633c50bfL15-R21): Changed exclusion of `.github/` to exclude specific files such as `development.md`, `CONTRIBUTING.md`, `INSTALL.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`, and `SUPPORT.md` while keeping the LICENSE file.