### PR TITLE
test(demo): add three different toml files for demo

### DIFF
--- a/tests/pep621/pyproject.toml
+++ b/tests/pep621/pyproject.toml
@@ -1,0 +1,26 @@
+# PEP 621 Test File - Instant Completion Support
+# Test completion by placing cursor after package names or version operators
+
+[project]
+name = "pep621-test"
+version = "0.1.0"
+description = "Test project for PEP 621 completion"
+dependencies = [
+    "requests",           # Cursor after package → shows version operators
+    "numpy>=",            # Cursor after >= → shows versions instantly
+    "pandas~=1.5",        # Cursor in version → shows alternatives
+    "django==4.",         # Cursor after 4. → shows patch versions
+    "fastapi^0.95",       # Cursor in version → shows compatible versions
+    "pytest[testing]>=7", # With extras - cursor after >= → shows versions
+]
+
+[project.optional-dependencies]
+dev = [
+    "black>=",     # Development dependencies also work
+    "isort~=5.12", # Cursor in version for alternatives
+    "mypy==1.",    # Type checking versions
+]
+
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/tests/poetry_v1/pyproject.toml
+++ b/tests/poetry_v1/pyproject.toml
@@ -1,0 +1,29 @@
+# Poetry v1 Test File - Perfect Completion Support
+# Test completion by placing cursor between quotes in version strings
+
+[tool.poetry]
+name = "poetry-v1-test"
+version = "0.1.0"
+description = "Test project for Poetry v1 completion"
+
+[tool.poetry.dependencies]
+python = "^3.9.13"    # Cursor in version → shows Python versions
+click = "~8.1"        # Cursor after 8. → shows patch versions
+httpx = "^0.23.0"     # Cursor in version → shows compatible versions
+requests = ">=2.28.0" # Cursor in version → shows available versions
+pydantic = "==1.10.7" # Cursor in version → shows exact matches
+fastapi = ""          # Empty version - cursor shows all versions
+
+[tool.poetry.group.dev.dependencies]
+pytest = "^7.2.0"  # Dev dependencies also work perfectly
+black = "~23.1"    # Cursor in version for alternatives
+isort = ">=5.12.0" # Multiple version operators supported
+mypy = ""          # Empty version for full list
+
+[tool.poetry.group.test.dependencies]
+coverage = "^7.1.0" # Test group dependencies
+pytest-cov = "~4.0" # Cursor in version shows alternatives
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"

--- a/tests/poetry_v2/pyproject.toml
+++ b/tests/poetry_v2/pyproject.toml
@@ -1,0 +1,28 @@
+# Poetry v2 Test File - Parentheses Format Support
+# Note: Requires more typing to trigger completion (acceptable trade-off)
+# Test by typing: "package (>=" then completion will trigger
+
+[project]
+name = "poetry-v2-test"
+version = "0.1.0"
+description = "Test project for Poetry v2 parentheses completion format"
+dependencies = [
+    "pandas (>=2.0,<3.0)",   # Parentheses format - type past ( for trigger
+    "numpy (==1.24.3)",      # Exact version in parentheses
+    "requests (^2.28.0)",    # Caret constraint in parentheses
+    "django (~=4.1.0)",      # Tilde constraint in parentheses
+    "fastapi",               # Simple package name works instantly
+    "pytest[testing] (>=7)", # With extras and parentheses
+]
+
+# Mixed format also works
+[tool.poetry.dependencies]
+python = "^3.9"  # Poetry v1 style still works
+click = "~8.1.0" # Traditional quoted format
+
+[tool.poetry.group.dev.dependencies]
+black = "23.1.0" # Unquoted also works (Poetry extension)
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
This pull request adds three new test files for different Python packaging formats to support and verify instant or improved completion features for dependency versions. Each file is tailored to a specific tool or format—PEP 621, Poetry v1, and Poetry v2—showing how completions should behave when the cursor is placed at various points within dependency declarations.

**Test coverage for dependency completion:**

* Added `tests/pep621/pyproject.toml` to test instant completion support for dependencies in PEP 621 format, including various version operators and extras.
* Added `tests/poetry_v1/pyproject.toml` to verify perfect completion support for Poetry v1, covering quoted version strings, dev/test groups, and empty version fields for full version lists.
* Added `tests/poetry_v2/pyproject.toml` to test parentheses format completion for Poetry v2, including mixed formats and more complex version constraints.