### PR TITLE
ci(hooks): enable tsc check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,8 +34,8 @@ repos:
         language: pygrep
         stages:
           - commit-msg
-      # - id: tsc-check
-      #   name: TypeScript type check
-      #   entry: npx tsc --noEmit
-      #   language: system
-      #   files: \.(ts|tsx)$
+      - id: tsc-check
+        name: TypeScript type check
+        entry: npx tsc --noEmit
+        language: system
+        files: \.(ts|tsx)$


### PR DESCRIPTION
This pull request re-enables the TypeScript type checking pre-commit hook in `.pre-commit-config.yaml`. This ensures that TypeScript files are checked for type errors before commits, helping to catch issues early in the development workflow.