### PR TITLE
docs(readme): add warning for poetry v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,11 @@ npm run watch           # Start development mode
   - Try different trigger characters (`=`, `~`, `>`, `<`, `space`) if completion doesn't appear
   - Use Tombo's debug logging to identify conflicts: `tombo.enableDebugLogging` → `true`
 
+**Poetry v2 syntax limitations:**
+- Poetry v2's parentheses syntax `"pandas (>=2.0,<3.0)"` doesn't honor PEP 621 standards
+- **Workaround**: Completion triggers on operators (`=`, `>`, `<`, `~`) but parentheses `( )` require manual typing
+- **Example**: Type `pandas >=` → completion works, but `pandas (>=` → you handle the parentheses manually
+
 **File naming requirements:**
 - Must be exactly `pyproject.toml` (not `*-pyproject.toml` or similar variants)
 - Requirements files must match `requirements*.txt` pattern


### PR DESCRIPTION
This pull request updates the documentation in `README.md` to clarify limitations and workarounds for Poetry v2 syntax when using completion features. It adds a new section explaining how the tool interacts with operator-based triggers and the parentheses syntax.

Poetry v2 syntax support and documentation:

* Added a new section describing Poetry v2's parentheses syntax limitation, noting that `"pandas (>=2.0,<3.0)"` is not fully supported according to PEP 621 standards.
* Provided a workaround: completion triggers on operators like `=`, `>`, `<`, and `~`, but parentheses must be typed manually. An example is included for clarity.