### PR TITLE
ci(workflows): implement pr & semantic release yamls

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,21 @@
+triage:
+  - changed-files:
+      - any-glob-to-any-file: '**/*'
+
+enhancement:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'src/**/*'
+
+workflows:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '.github/**/*'
+
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - README.md
+          - '**/*.md'
+          - 'docs/**/*.md'
+          - 'docs/mkdocs.yml'

--- a/.github/workflows/pull-request-target.yml
+++ b/.github/workflows/pull-request-target.yml
@@ -1,0 +1,29 @@
+name: pull-request-target-workflows
+
+on:
+  pull_request_target:
+    branches:
+      - main
+    types:
+      - opened
+      - synchronize
+      - edited
+      - reopened
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-target
+  cancel-in-progress: true
+
+jobs:
+  pr-labeler:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - uses: actions/labeler@v5
+        continue-on-error: true
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/labeler.yml

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,21 @@
+name: 'pull request workflow'
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - synchronize
+      - edited
+      - reopened
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pre-commit:
+    name: pre-commit checks
+    uses: benbenbang/tombo/.github/workflows/pre-commit.yml@workflows
+    secrets: inherit

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -1,0 +1,37 @@
+name: semantic release
+
+on:
+  workflow_dispatch:
+    inputs:
+      prompt:
+        description: 'If you are sure to launch a new release, put the value to true.'
+        default: 'false'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  packages: write
+  statuses: write
+
+jobs:
+  semantic-release:
+    if: github.event.inputs.prompt == 'true'
+    uses: benbenbang/tombo/.github/workflows/reusable-sr.yml@workflows
+    secrets: inherit
+
+  update-release-title:
+    runs-on: ubuntu-latest
+    needs: semantic-release
+    if: ${{ needs.semantic-release.outputs.new_release != null }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: update github release
+        run: |
+          gh release edit -R ${{ github.repository }} --title "🧽 Tombo ${{ needs.semantic-release.outputs.new_release_tag }}" "${{ needs.semantic-release.outputs.new_release_tag }}"
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
This pull request introduces several new GitHub workflow files and a label configuration to automate and improve PR labeling and release management. The changes focus on enhancing CI/CD automation, PR triage, and semantic release processes.

**Workflow Automation Enhancements:**

* Added `.github/workflows/pull-request.yml` to automatically label pull requests based on file changes, improving PR triage and organization.
* Added `.github/workflows/pull-request-target.yml` to enable labeling of PRs opened with the `pull_request_target` event, supporting workflows that require elevated permissions.

**Labeling Configuration:**

* Introduced `.github/labeler.yml` to define labeling rules for triage, enhancements, workflows, and documentation based on file paths and patterns.

**Release Management Automation:**

* Added `.github/workflows/semantic-release.yml` to support semantic release via workflow dispatch, including an approval prompt and automated release title updates using the output of the semantic release job.