### PR TITLE
docs(license): update year to reflect the current year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 # MIT License
 
-Copyright (c) 2023 Ben CHEN <@benbenbang>
+Copyright (c) 2025 Ben CHEN <@benbenbang>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This pull request updates the copyright year in the `LICENSE` file to reflect the current year.

* Updated the copyright year from 2023 to 2025 in the `LICENSE` file.